### PR TITLE
Update carousel post counter

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            2.25.5
+// @version            2.25.6
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！
@@ -1404,7 +1404,7 @@
      */
     function createDownloadButton(){
         // Add download icon per each posts
-        $('article, section:visible > main > div > div.xdt5ytf, div._aap0[role="presentation"]').each(function(index){
+        $('article, section:visible > main > div > div.xdt5ytf, *:not(._aauo) > * > div._aap0[role="presentation"]').each(function(index){
             // If it is have not download icon
             // class x1iyjqo2 mean user profile pages post list container
             if(!$(this).attr('data-snig') && !$(this).hasClass('x1iyjqo2') && !$(this).children('article')?.hasClass('x1iyjqo2')){
@@ -1436,13 +1436,15 @@
 
                 console.log("Found insert point", $childElement);
 
-                // Has counter?!
-                if($mainElement.find('._aao_ + div.x6s0dn4').length > 0){
-                    $mainElement.find('._aao_ + div.x6s0dn4').css('top', '35px');
+                // Modify carousel post counter's position to not interfere with our buttons
+                if($mainElement.find('._aap0').length > 0){
+                    if($mainElement.find('._aap0 + .x24i39r').length > 0){
+                        $mainElement.find('._aap0 + .x24i39r').css('top', '37px');
+                    }
 
-                    const observeNode = $mainElement.find('._aao_ + div.x6s0dn4').first().parent()[0];
+                    const observeNode = $mainElement.find('._aap0').first().parent()[0];
                     var observer = new MutationObserver(function (mutation, owner) {
-                        $mainElement.find('._aao_ + div.x6s0dn4').css('top', '35px');
+                        $mainElement.find('._aap0 + .x24i39r').css('top', '37px');
                     });
 
                     observer.observe(observeNode, {


### PR DESCRIPTION
Instagram recently made another update - they added back the carousel post counter.

![](https://github.com/user-attachments/assets/77dbc855-9e76-4bfd-86b6-fb0c015f8f29)

By the way, I also made this change: `*:not(._aauo) > * > div._aap0[role="presentation"]`

This is because `div._aap0[role="presentation"]` is also used for the stories section on the Instagram home page.

Adding `*:not(._aauo) > * >` also fixes this issue I've noticed a time ago:
![Screenshot_82](https://github.com/user-attachments/assets/555109cf-572a-40c1-9442-3278feefe239)

The download button was misplaced on those stories on the home page.