### PR TITLE
Fix isProfile + fix misplacing buttons in Saved page

### DIFF
--- a/main.js
+++ b/main.js
@@ -191,7 +191,7 @@
 
                 pageLoaded = true;
             }
-            if($('header > section:first img[alt]').length && location.pathname.match(/^(\/)([0-9A-Za-z\.\-_]+)\/?(tagged|reels)?\/?$/ig) && !location.pathname.match(/^(\/explore\/?$|\/stories(\/.*)?$|\/p\/)/ig)) {
+            if($('header > section:first img[alt]').length && location.pathname.match(/^(\/)([0-9A-Za-z\.\-_]+)\/?(tagged|reels|saved)?\/?$/ig) && !location.pathname.match(/^(\/explore\/?$|\/stories(\/.*)?$|\/p\/)/ig)) {
                 console.log('isProfile');
                 setTimeout(()=>{
                     onProfileAvatar(false);

--- a/main.js
+++ b/main.js
@@ -128,7 +128,6 @@
     var timer = setInterval(function(){
         // page loading or unnecessary route
         if($('div#splash-screen').length > 0 && !$('div#splash-screen').is(':hidden') ||
-           $('header svg > path[d^="M14.232 3.656a1.269"]').length > 0 ||
            location.pathname.match(/^\/(explore(\/.*)?|challenge\/?.*|direct\/?.*|qr\/?|accounts\/.*|emails\/.*|language\/?.*?|your_activity\/?.*|settings\/help(\/.*)?$)$/ig) ||
            !location.hostname.startsWith('www.')
           ){
@@ -192,7 +191,7 @@
 
                 pageLoaded = true;
             }
-            if($('header img[alt][draggable]').length && location.pathname.match(/^(\/)([0-9A-Za-z\.\-_]+)\/?(tagged|reels)?\/?$/ig) && !location.pathname.match(/^(\/explore\/?$|\/stories(\/.*)?$|\/p\/)/ig)) {
+            if($('header > section:first img[alt]').length && location.pathname.match(/^(\/)([0-9A-Za-z\.\-_]+)\/?(tagged|reels)?\/?$/ig) && !location.pathname.match(/^(\/explore\/?$|\/stories(\/.*)?$|\/p\/)/ig)) {
                 console.log('isProfile');
                 setTimeout(()=>{
                     onProfileAvatar(false);
@@ -287,8 +286,10 @@
                         return;
                     }
 
-                    $('header img[alt][draggable]').parent().parent().append(`<div title="${_i18n("DW")}" class="IG_DWPROFILE">${SVG.DOWNLOAD}</div>`);
-                    $('header img[alt][draggable]').parent().parent().css('position','relative');
+                    $('header > section:first img[alt][draggable]').parent().parent().append(`<div title="${_i18n("DW")}" class="IG_DWPROFILE">${SVG.DOWNLOAD}</div>`);
+                    $('header > section:first img[alt][draggable]').parent().parent().css('position','relative');
+                    $('header > section:first img[alt]:not([draggable])').parent().parent().parent().append(`<div title="${_i18n("DW")}" class="IG_DWPROFILE">${SVG.DOWNLOAD}</div>`);
+                    $('header > section:first img[alt]:not([draggable])').parent().parent().parent().css('position','relative');
                 },150);
             }
         }
@@ -1520,7 +1521,7 @@
      */
     function createDownloadButton(){
         // Add download icon per each posts
-        $('article, section:visible > main > div > div.xdt5ytf, div._aap0[role="presentation"]').each(function(index){
+        $('article[class], section:visible > main > div > div.xdt5ytf[style], div._aap0[role="presentation"]').each(function(index){
             // If it is have not download icon
             // class x1iyjqo2 mean user profile pages post list container
             if(!$(this).attr('data-snig') && !$(this).hasClass('x1iyjqo2') && !$(this).children('article')?.hasClass('x1iyjqo2') && $(this).parents('div#scrollview').length === 0){

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            2.28.6
+// @version            2.28.7
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！


### PR DESCRIPTION
- Profile pic download button was placed for highlights too. Whoops. 🤣
- Let people download their own profile pics if they want to. I want to state that I am not against this, initially I wasn't sure if I should care for a feature that never worked for your own profile, that's all. Now it will work, at least. 😎
- Fix misplacing buttons in the Saved page (`/saved/all-posts/`), this happened:
![](https://github.com/user-attachments/assets/6e5adb84-21cc-443e-8a07-e5bb659ef6a5)

**_[Again, it's very tricky to trigger this, you have to switch between `/saved/all-posts/` URL and Home very fast, and at some point this would happen.]_**

Posts having tag `article` should always have attribute `class`, and `section:visible > main > div > div.xdt5ytf` should always have attribute `style`.

That's how I fixed the above bug, by making sure `[class]` and `[style]` exist for them.