### PR TITLE
Use relative position for independent post

### DIFF
--- a/main.js
+++ b/main.js
@@ -1525,7 +1525,10 @@
      */
     function createDownloadButton(){
         // Add download icon per each posts
-        $('article[class], section:visible > main > div > div.xdt5ytf[style], div._aap0[role="presentation"]').each(function(index){
+        $('article[class], section:visible > main > div > div > div > div > div > hr').map(function(index){
+            return $(this).is('section:visible > main > div > div > div > div > div > hr') ? $(this).parent().parent().parent().parent()[0] : this;
+    	})
+    	.each(function(index){
             // If it is have not download icon
             // class x1iyjqo2 mean user profile pages post list container
             if(!$(this).attr('data-snig') && !$(this).hasClass('x1iyjqo2') && !$(this).children('article')?.hasClass('x1iyjqo2') && $(this).parents('div#scrollview').length === 0){

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            2.28.9.1
+// @version            2.28.10
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！


### PR DESCRIPTION
- It seems that Instagram got rid of `div._aap0[role="presentation"]`, so it can be removed.
- Instagram stopped adding `style` attribute for `section:visible > main > div > div.xdt5ytf` and since `xdt5ytf` is not a very distinct element in the page, we could use the relative position in the DOM.
- `<hr>` element is more unique than `div.xdt5ytf` element.

**_By independent post I mean the post you see when you directly open a URL post into a new tab._**