### PR TITLE
Get rid of `div.xdt5ytf`

### DIFF
--- a/main.js
+++ b/main.js
@@ -151,8 +151,11 @@
 
                 // This is a delayed function call that prevents the dialog element from appearing before the function is called.
                 var dialogTimer = setInterval(()=>{
-                    // "body > div[id^="mount"] section nav + div > article" is mobile page in single post
-                    if($('body > div[class]:not([id^="mount"]) div div[role="dialog"] article, section:visible > main > div > div.xdt5ytf, body > div[id^="mount"] section nav + div > article').length > 0){
+                    // body > div[id^="mount"] section nav + div > article << (mobile page in single post) >>
+                    // section:visible > main > div > div > div > div > div > hr << (single foreground post in page, non-floating // <hr> element here is literally the line beneath poster's username) >>
+                    // section:visible > main > div > div.xdt5ytf << (former CSS selector for single foreground post in page, non-floating) >>
+                    // <hr> is much more unique element than "div.xdt5ytf"
+                    if($('body > div[class]:not([id^="mount"]) div div[role="dialog"] article, section:visible > main > div > div > div > div > div > hr, body > div[id^="mount"] section nav + div > article').length > 0){
                         clearInterval(dialogTimer);
 
                         // This is to prevent the detection of the "Modify Video Volume" setting from being too slow.
@@ -1377,8 +1380,10 @@
             const maxCall = 100;
             let i = 0;
             var repeat = setInterval(() => {
-                // div.xdt5ytf << (sigle post in top, not floating) >>
-                if(i > maxCall || $('article[data-snig="canDownload"], section:visible > main > div > div.xdt5ytf[data-snig="canDownload"], div[id^="mount"] > div > div > div.x1n2onr6.x1vjfegm div[data-snig="canDownload"]').length > 0){
+                // section:visible > main > div > div[data-snig="canDownload"] > div > div > div > hr << (single foreground post in page, non-floating // <hr> element here is literally the line beneath poster's username) >>
+                // section:visible > main > div > div.xdt5ytf[data-snig="canDownload"] << (former CSS selector for single foreground post in page, non-floating) >>
+                // <hr> is much more unique element than "div.xdt5ytf"
+                if(i > maxCall || $('article[data-snig="canDownload"], section:visible > main > div > div[data-snig="canDownload"] > div > div > div > hr, div[id^="mount"] > div > div > div.x1n2onr6.x1vjfegm div[data-snig="canDownload"]').length > 0){
                     clearInterval(repeat);
 
                     if(i > maxCall){

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            2.29.1
+// @version            2.29.2
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            2.28.12
+// @version            2.29.1
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！


### PR DESCRIPTION
- Since we already use `section:visible > main > div > div > div > div > div > hr` at the beggining of function **`createDownloadButton`**, it makes more sense to use this everywhere.
- I also added small comments and the previous CSS selector is still mentioned in these comments, just in case.