### PR TITLE
Embed the post url into the EXIF tags

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default [
         ...globals.browser,
         $: 'readonly',
         jQuery: 'readonly',
+        piexif: 'readonly',
         GM_info: 'readable',
         GM_addStyle: 'readable',
         GM_setValue: 'readable',

--- a/main.js
+++ b/main.js
@@ -27,7 +27,6 @@
 // @connect            i.instagram.com
 // @connect            raw.githubusercontent.com
 // @require            https://code.jquery.com/jquery-3.7.1.min.js#sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=
-// @require            https://cdn.jsdelivr.net/npm/piexifjs
 // @resource           INTERNAL_CSS https://raw.githubusercontent.com/SN-Koarashi/ig-helper/master/style.css
 // @resource           LOCALE_MANIFEST https://raw.githubusercontent.com/SN-Koarashi/ig-helper/master/locale/manifest.json
 // @supportURL         https://github.com/SN-Koarashi/ig-helper/

--- a/main.js
+++ b/main.js
@@ -2858,37 +2858,6 @@
     }
 
     /**
-     * @description Convert base64 DataURL string to Blob
-     * 
-     * @param {string} dataurl
-     * @return {Blob}
-     */
-    function dataURLtoBlob(dataurl) {
-        const [header, b64] = dataurl.split(',');
-        const mime = header.match(/:(.*?);/)[1];
-        const binary = atob(b64);
-        const buffer = new Uint8Array(binary.length);
-        for (let i = 0; i < binary.length; i++) {
-            buffer[i] = binary.charCodeAt(i);
-        }
-        return new Blob([buffer], { type: mime });
-    }
-
-    /**
-     * @description Trigger download from Blob with filename
-     * 
-     * @param {Blob} blob
-     * @param {string} filename
-     */
-    function triggerDownload(blob, filename) {
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = filename;
-        link.click();
-        link.remove();
-    }
-
-    /**
      * createSaveFileElement
      * @description Download the specified media with link element
      *
@@ -2942,25 +2911,11 @@
         });
 
         const originally = username + '_' + original_name + '.' + filetype;
-        const downloadName = USER_SETTING.AUTO_RENAME ? filename + '.' + filetype : originally;
 
-        if (filetype === 'jpg' && shortcode && sourceType == 'photo') {
-            const reader = new FileReader();
-            reader.onload = function(e) {
-                const b64 = e.target.result;
-                const zeroth = {};
-                zeroth[piexif.ImageIFD.ImageDescription] =
-                    `https://www.instagram.com/p/${shortcode}/`;
-                const exifObj = { '0th': zeroth, 'Exif': {}, 'GPS': {}, '1st': {}, 'thumbnail': null };
-                const exifBytes = piexif.dump(exifObj);
-                const newB64 = piexif.insert(exifBytes, b64);
-                const newBlob = dataURLtoBlob(newB64);
-                triggerDownload(newBlob, downloadName);
-            };
-            reader.readAsDataURL(object);
-        } else {
-            triggerDownload(object, downloadName);
-        }
+        a.href = URL.createObjectURL(object);
+        a.setAttribute("download", (USER_SETTING.AUTO_RENAME) ? filename + '.' + filetype : originally);
+        a.click();
+        a.remove();
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "globals": "^15.14.0"
   },
   "dependencies": {
-    "jquery": "^3.7.1"
+    "jquery": "^3.7.1",
+    "piexifjs": "^1.0.6"
   }
 }

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -27,6 +27,7 @@
 // @connect            i.instagram.com
 // @connect            raw.githubusercontent.com
 // @require            https://code.jquery.com/jquery-3.7.1.min.js#sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=
+// @require            https://cdn.jsdelivr.net/npm/piexifjs@1.0.6/piexif.min.js#sha256-JbSirLOu9KeEGo4tAOxJrerAXvlp8fHxSpS3wVndlBA=
 // @resource           INTERNAL_CSS https://raw.githubusercontent.com/SN-Koarashi/ig-helper/master/style.css
 // @resource           LOCALE_MANIFEST https://raw.githubusercontent.com/SN-Koarashi/ig-helper/master/locale/manifest.json
 // @supportURL         https://github.com/SN-Koarashi/ig-helper/

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -184,11 +184,11 @@ export function saveFiles(downloadLink, username, sourceType, timestamp, filetyp
 /**
  * @description Convert base64 DataURL string to Blob
  * 
- * @param {string} dataurl
+ * @param {string} dataURL
  * @return {Blob}
  */
-function dataURLtoBlob(dataurl) {
-    const [header, b64] = dataurl.split(',');
+function dataURLtoBlob(dataURL) {
+    const [header, b64] = dataURL.split(',');
     const mime = header.match(/:(.*?);/)[1];
     const binary = atob(b64);
     const buffer = new Uint8Array(binary.length);
@@ -234,7 +234,6 @@ export function createSaveFileElement(downloadLink, object, username, sourceType
 
     const date = new Date(timestamp);
 
-    const a = document.createElement("a");
     const original_name = new URL(downloadLink).pathname.split('/').at(-1).split('.').slice(0, -1).join('.');
     const year = date.getFullYear().toString();
     const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -269,7 +268,7 @@ export function createSaveFileElement(downloadLink, object, username, sourceType
     const downloadName = USER_SETTING.AUTO_RENAME ? filename + '.' + filetype : originally;
     if (filetype === 'jpg' && shortcode && sourceType == 'photo') {
         const reader = new FileReader();
-        reader.onload = function(e) {
+        reader.onload = function (e) {
             const b64 = e.target.result;
             const zeroth = {};
             zeroth[piexif.ImageIFD.ImageDescription] =


### PR DESCRIPTION
Keeping the original post url in the EXIF tags allows the users to be able to search the contents of the files by the actual post link and be able to find it.

