### PR TITLE
bugfix: Actually check the type of the file to be jpeg

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            3.4.3
+// @version            3.4.4
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！
@@ -2942,7 +2942,7 @@
 
         const originally = username + '_' + original_name + '.' + filetype;
         const downloadName = USER_SETTING.AUTO_RENAME ? filename + '.' + filetype : originally;
-        if (filetype === 'jpg' && shortcode && sourceType == 'photo') {
+        if (filetype === 'jpg' && shortcode && sourceType == 'photo' && object.type === 'image/jpeg') {
             const reader = new FileReader();
             reader.onload = function (e) {
                 const b64 = e.target.result;

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -5,7 +5,7 @@
 // @name:ja            IG助手
 // @name:ko            IG조수
 // @namespace          https://github.snkms.com/
-// @version            3.4.3
+// @version            3.4.4
 // @description        Downloading is possible for both photos and videos from posts, as well as for stories, reels or profile picture.
 // @description:zh-TW  一鍵下載對方 Instagram 貼文中的相片、影片甚至是他們的限時動態、連續短片及大頭貼圖片！
 // @description:zh-CN  一键下载对方 Instagram 帖子中的相片、视频甚至是他们的快拍、Reels及头像图片！

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -266,7 +266,7 @@ export function createSaveFileElement(downloadLink, object, username, sourceType
 
     const originally = username + '_' + original_name + '.' + filetype;
     const downloadName = USER_SETTING.AUTO_RENAME ? filename + '.' + filetype : originally;
-    if (filetype === 'jpg' && shortcode && sourceType == 'photo') {
+    if (filetype === 'jpg' && shortcode && sourceType == 'photo' && object.type === 'image/jpeg') {
         const reader = new FileReader();
         reader.onload = function (e) {
             const b64 = e.target.result;


### PR DESCRIPTION
Since the webp are saved as a `.jpg` but are not actual JPEG files, `piexif.js` tries to modify them and throws an error.