### PR TITLE
Update Translations and Optimize Others

### DIFF
--- a/locale/translations/es.json
+++ b/locale/translations/es.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "¡Wololo! Nueva versión disponible.",
     "NOTICE_UPDATE_CONTENT": "IG-Helper ha lanzado una nueva versión, haz clic aquí para actualizar.",
-    "CHECK_UPDATE": "Comprobar actualizaciones del script",
-    "CHECK_UPDATE_MENU": "Comprobar actualizaciones",
-    "CHECK_UPDATE_INTRO": "Comprobar actualizaciones cuando se ejecuta el script (comprueba cada 300 segundos).\nLas notificaciones de actualización se enviarán como notificaciones de escritorio a través del navegador.",
+    "CHECK_FOR_UPDATE": "Comprobar actualizaciones del script",
     "RELOAD_SCRIPT": "Recargar script",
     "DONATE": "Donar",
     "FEEDBACK": "Comentarios",
@@ -24,7 +22,7 @@
     "VID": "Vídeo",
     "DW": "Descargar",
     "DW_ALL": "Descargar todos los recursos",
-    "THUMBNAIL_INTRO": "Descargar miniatura del vídeo",
+    "VIDEO_THUMBNAIL": "Descargar miniatura del vídeo",
     "LOAD_BLOB_ONE": "Cargando el medio Blob...",
     "LOAD_BLOB_MULTIPLE": "Cargando el medio Blob y otros...",
     "LOAD_BLOB_RELOAD": "Detectando el medio Blob, recargando...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Usar métodos alternativos para descargar cuando la API de Media no es accesible",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "\"Abrir en una pestaña nueva\" en las publicaciones siempre usa la API de Media",
     "SKIP_VIEW_STORY_CONFIRM": "Omitir la página de confirmación al ver una historia o un contenido destacado",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capturar recurso de imagen usando la caché multimedia",
     "AUTO_RENAME_INTRO": "Renombrar archivos automáticamente a un formato personalizado\nLista de formatos personalizados: \n%USERNAME% - Nombre de usuario\n%SOURCE_TYPE% - Tipo de fuente\n%SHORTCODE% - Código corto de la publicación\n%YEAR% - Año de descarga/publicación\n%2-YEAR% - Año (últimos dos dígitos) de descarga/publicación\n%MONTH% - Mes de descarga/publicación\n%DAY% - Día de descarga/publicación\n%HOUR% - Hora de descarga/publicación\n%MINUTE% - Minuto de descarga/publicación\n%SECOND% - Segundo de descarga/publicación\n%ORIGINAL_NAME% - Nombre original del archivo descargado\n%ORIGINAL_NAME_FIRST% - Nombre original del archivo descargado (primera parte del nombre)\n\nSi se establece en falso, el nombre del archivo permanecerá sin cambios.\nEjemplo: instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "Establece la marca de tiempo en el formato de renombramiento de archivos a la fecha de publicación del recurso (zona horaria del navegador).\n\nEsta función solo funciona cuando [Renombrar archivos automáticamente] está establecido en VERDADERO.",
     "RENAME_LOCATE_DATE_INTRO": "Modificar el formato de fecha de la marca de tiempo del archivo renombrado a la hora local del navegador y formatearlo a su formato de fecha regional preferido.\n\nEsta función solo funciona cuando [Renombrar archivos automáticamente] está establecido en VERDADERO.",
@@ -62,7 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "La API de Media intentará obtener la foto o el vídeo de mayor calidad posible, pero puede tardar más en cargarse.",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "Cuando la API de Media alcanza su límite de tasa o no se puede usar por otras razones, se utilizará la API de obtención forzada para descargar recursos (la calidad del recurso puede ser ligeramente inferior).",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "El botón [Abrir en una pestaña nueva] en las publicaciones siempre usará la API de Media para obtener recursos de alta resolución.",
+    "CHECK_FOR_UPDATE_INTRO": "Comprobar actualizaciones cuando se ejecuta el script (comprueba cada 300 segundos).\nLas notificaciones de actualización se enviarán como notificaciones de escritorio a través del navegador.",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "Omitir automáticamente cuando se muestra la página de confirmación en la historia o el contenido destacado.",
     "MODIFY_RESOURCE_EXIF_INTRO": "Modificar los atributos EXIF del recurso de imagen para colocar el enlace de la publicación en él.",
-    "DIRECT_DOWNLOAD_STORY_INTRO": "Al hacer clic en 'Descargar todos los recursos', todas las historias/destacados se descargan directamente, sin mostrar el cuadro de diálogo de selección de imágenes."
+    "DIRECT_DOWNLOAD_STORY_INTRO": "Al hacer clic en 'Descargar todos los recursos', todas las historias/destacados se descargan directamente, sin mostrar el cuadro de diálogo de selección de imágenes.",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Usa un observador para capturar cualquier URL de imágenes de alta calidad en el árbol DOM en el almacenamiento del script, de modo que puedan extraerse cuando estén disponibles y a petición del usuario."
 }

--- a/locale/translations/fr.json
+++ b/locale/translations/fr.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "Wololo ! Nouvelle version disponible.",
     "NOTICE_UPDATE_CONTENT": "IG-Helper a publié une nouvelle version, cliquez ici pour mettre à jour.",
-    "CHECK_UPDATE": "Vérifier les mises à jour du script",
-    "CHECK_UPDATE_MENU": "Vérifier les mises à jour",
-    "CHECK_UPDATE_INTRO": "Vérifier les mises à jour lorsque le script est déclenché (vérification toutes les 300 secondes).\nLes notifications de mise à jour seront envoyées en tant que notifications de bureau via le navigateur.",
+    "CHECK_FOR_UPDATE": "Vérifier les mises à jour du script",
     "RELOAD_SCRIPT": "Recharger le script",
     "DONATE": "Faire un don",
     "FEEDBACK": "Commentaires",
@@ -24,7 +22,7 @@
     "VID": "Vidéo",
     "DW": "Télécharger",
     "DW_ALL": "Télécharger toutes les ressources",
-    "THUMBNAIL_INTRO": "Télécharger la miniature de la vidéo",
+    "VIDEO_THUMBNAIL": "Télécharger la miniature de la vidéo",
     "LOAD_BLOB_ONE": "Chargement du média Blob...",
     "LOAD_BLOB_MULTIPLE": "Chargement du média Blob et autres...",
     "LOAD_BLOB_RELOAD": "Détection du média Blob, rechargement...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Utiliser des méthodes alternatives de téléchargement lorsque l'API Media n'est pas accessible",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "« Ouvrir dans un nouvel onglet » dans les posts utilise toujours l'API Media",
     "SKIP_VIEW_STORY_CONFIRM": "Ignorer la page de confirmation lors de la visualisation d'une story ou d'un contenu à la une",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capturer une ressource d’image en utilisant le cache multimédia",
     "AUTO_RENAME_INTRO": "Renommer automatiquement les fichiers dans un format personnalisé\nListe des formats personnalisés : \n%USERNAME% - Nom d'utilisateur\n%SOURCE_TYPE% - Type de source\n%SHORTCODE% - Code court du post\n%YEAR% - Année de téléchargement/publication\n%2-YEAR% - Année (deux derniers chiffres) de téléchargement/publication\n%MONTH% - Mois de téléchargement/publication\n%DAY% - Jour de téléchargement/publication\n%HOUR% - Heure de téléchargement/publication\n%MINUTE% - Minute de téléchargement/publication\n%SECOND% - Seconde de téléchargement/publication\n%ORIGINAL_NAME% - Nom original du fichier téléchargé\n%ORIGINAL_NAME_FIRST% - Nom original du fichier téléchargé (première partie du nom)\n\nSi défini sur faux, le nom du fichier restera inchangé.\nExemple : instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "Définit l'horodatage dans le format de renommage de fichier à la date de publication de la ressource (fuseau horaire du navigateur).\n\nFonctionne UNIQUEMENT si [Renommer automatiquement les fichiers] est défini sur VRAI.",
     "RENAME_LOCATE_DATE_INTRO": "Modifier le format de date de l'horodatage de renommage de fichier à l'heure locale du navigateur et le formater selon le format de date régional souhaité.\n\nFonctionne UNIQUEMENT si [Renommer automatiquement les fichiers] est défini sur VRAI.",
@@ -62,7 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "L'API Media essaiera d'obtenir la meilleure qualité possible pour les photos ou les vidéos, mais le chargement prendra plus de temps.",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "Lorsque l'API Media atteint sa limite de taux ou ne peut pas être utilisée pour d'autres raisons, l'API de récupération forcée sera utilisée pour télécharger les ressources (la qualité des ressources peut être légèrement inférieure).",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "Le bouton [Ouvrir dans un nouvel onglet] dans les posts utilisera toujours l'API Media pour obtenir des ressources en haute résolution.",
+    "CHECK_FOR_UPDATE_INTRO": "Vérifier les mises à jour lorsque le script est déclenché (vérification toutes les 300 secondes).\nLes notifications de mise à jour seront envoyées en tant que notifications de bureau via le navigateur.",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "Ignorer automatiquement lorsque la page de confirmation est affichée dans la story ou le contenu à la une.",
     "MODIFY_RESOURCE_EXIF_INTRO": "Modifier les attributs EXIF de la ressource image afin de placer le lien du post à l'intérieur.",
-    "DIRECT_DOWNLOAD_STORY_INTRO": "Lorsque vous cliquez sur « Télécharger toutes les ressources », toutes les stories/à la une sont téléchargées directement, sans afficher la boîte de dialogue de sélection des images."
+    "DIRECT_DOWNLOAD_STORY_INTRO": "Lorsque vous cliquez sur « Télécharger toutes les ressources », toutes les stories/à la une sont téléchargées directement, sans afficher la boîte de dialogue de sélection des images.",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Utilise un watcher pour capturer tous les URL d’images de haute qualité dans l’arbre DOM dans le stockage du script, afin qu’ils puissent être extraits lorsqu’ils sont disponibles et à la demande de l’utilisateur."
 }

--- a/locale/translations/it.json
+++ b/locale/translations/it.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "Wololo! Nuova versione rilasciata.",
     "NOTICE_UPDATE_CONTENT": "IG-Helper ha rilasciato una nuova versione, clicca qui per aggiornare.",
-    "CHECK_UPDATE": "Controllo aggiornamenti per lo script",
-    "CHECK_UPDATE_MENU": "Controllo aggiornamenti",
-    "CHECK_UPDATE_INTRO": "Controlla gli aggiornamenti quando lo script viene attivato (controlla ogni 300 secondi).\nLe notifiche di aggiornamento saranno inviate come notifiche desktop tramite il browser.",
+    "CHECK_FOR_UPDATE": "Controllo aggiornamenti per lo script",
     "RELOAD_SCRIPT": "Ricarica lo script",
     "DONATE": "Dona",
     "FEEDBACK": "Feedback",
@@ -24,7 +22,7 @@
     "VID": "Video",
     "DW": "Scarica",
     "DW_ALL": "Scarica tutte le risorse",
-    "THUMBNAIL_INTRO": "Scarica la miniatura del video",
+    "VIDEO_THUMBNAIL": "Scarica la miniatura del video",
     "LOAD_BLOB_ONE": "Caricamento del contenuto multimediale in formato Blob...",
     "LOAD_BLOB_MULTIPLE": "Caricamento dei contenuti multimediali in formato Blob e altri...",
     "LOAD_BLOB_RELOAD": "Rilevamento del contenuto multimediale in formato Blob, ricaricamento...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Utilizza metodi alternativi per scaricare quando l'API Media non è accessibile",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "\"Apri in una nuova scheda\" nei post utilizza sempre l'API Media",
     "SKIP_VIEW_STORY_CONFIRM": "Salta la pagina di conferma per la visualizzazione di una storia o di un contenuto in evidenza",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Cattura risorsa immagine utilizzando la cache multimediale",
     "AUTO_RENAME_INTRO": "Rinomina automaticamente i file in un formato personalizzato\nElenco dei formati personalizzati: \n%USERNAME% - Nome utente\n%SOURCE_TYPE% - Tipo di sorgente\n%SHORTCODE% - Codice breve del post\n%YEAR% - Anno di download/pubblicazione\n%2-YEAR% - Anno (ultime due cifre) di download/pubblicazione\n%MONTH% - Mese di download/pubblicazione\n%DAY% - Giorno di download/pubblicazione\n%HOUR% - Ora di download/pubblicazione\n%MINUTE% - Minuto di download/pubblicazione\n%SECOND% - Secondo di download/pubblicazione\n%ORIGINAL_NAME% - Nome originale del file scaricato\n%ORIGINAL_NAME_FIRST% - Nome originale del file scaricato (prima parte del nome)\n\nSe impostato su falso, il nome del file rimarrà invariato.\nEsempio: instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "Imposta il timestamp nel formato di ridenominazione del file alla data di pubblicazione della risorsa (fuso orario del browser).\n\nFunziona SOLO se [Rinomina automaticamente i file] è impostato su VERO.",
     "RENAME_LOCATE_DATE_INTRO": "Modifica il formato della data del timestamp di ridenominazione del file all'ora locale del browser e formattalo nel formato data regionale desiderato.\n\nFunziona SOLO se [Rinomina automaticamente i file] è impostato su VERO.",
@@ -62,7 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "L'API Media proverà a ottenere la massima qualità possibile per foto o video, ma il caricamento richiederà più tempo.",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "Quando l'API Media raggiunge il limite di richieste o non può essere utilizzata per altri motivi, l'API di recupero forzato verrà utilizzata per scaricare le risorse (la qualità delle risorse potrebbe essere leggermente inferiore).",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "Il pulsante [Apri in una nuova scheda] nei post utilizzerà sempre l'API Media per ottenere risorse ad alta risoluzione.",
+    "CHECK_FOR_UPDATE_INTRO": "Controlla gli aggiornamenti quando lo script viene attivato (controlla ogni 300 secondi).\nLe notifiche di aggiornamento saranno inviate come notifiche desktop tramite il browser.",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "Salta automaticamente quando la pagina di conferma viene visualizzata nella storia o nel contenuto in evidenza.",
     "MODIFY_RESOURCE_EXIF_INTRO": "Modifica le proprietà EXIF della risorsa immagine per posizionare il link del post al suo interno.",
-    "DIRECT_DOWNLOAD_STORY_INTRO": "Quando fai clic su 'Scarica tutte le risorse', tutte le storie e gli elementi in evidenza vengono scaricati direttamente, senza mostrare la finestra di dialogo di selezione delle immagini."
+    "DIRECT_DOWNLOAD_STORY_INTRO": "Quando fai clic su 'Scarica tutte le risorse', tutte le storie e gli elementi in evidenza vengono scaricati direttamente, senza mostrare la finestra di dialogo di selezione delle immagini.",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Utilizza un watcher per catturare nella memoria dello script tutti gli URL di immagini ad alta qualità presenti nell’albero DOM, in modo che possano essere estratti quando disponibili e su richiesta dell’utente."
 }

--- a/locale/translations/pt.json
+++ b/locale/translations/pt.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "Wololo! Nova versão lançada.",
     "NOTICE_UPDATE_CONTENT": "IG-Helper lançou uma nova versão, clique aqui para atualizar.",
-    "CHECK_UPDATE": "Verificar atualizações do script",
-    "CHECK_UPDATE_MENU": "Verificar atualizações",
-    "CHECK_UPDATE_INTRO": "Verificar atualizações quando o script é acionado (verificar a cada 300 segundos).\nAs notificações de atualização serão enviadas como notificações de desktop através do navegador.",
+    "CHECK_FOR_UPDATE": "Verificar atualizações do script",
     "RELOAD_SCRIPT": "Recarregar script",
     "DONATE": "Doar",
     "FEEDBACK": "Feedback",
@@ -24,7 +22,7 @@
     "VID": "Vídeo",
     "DW": "Baixar",
     "DW_ALL": "Baixar todos os recursos",
-    "THUMBNAIL_INTRO": "Baixar miniatura do vídeo",
+    "VIDEO_THUMBNAIL": "Baixar miniatura do vídeo",
     "LOAD_BLOB_ONE": "Carregando a mídia Blob...",
     "LOAD_BLOB_MULTIPLE": "Carregando a mídia Blob e outros...",
     "LOAD_BLOB_RELOAD": "Detectando a mídia Blob, recarregando...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Usar métodos alternativos para baixar quando a API de Mídia não estiver acessível",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "\"Abrir em nova aba\" nas publicações sempre usa a API de Mídia",
     "SKIP_VIEW_STORY_CONFIRM": "Pular a página de confirmação ao visualizar uma story ou um destaque",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capturar recurso de imagem usando o cache de mídia",
     "AUTO_RENAME_INTRO": "Renomear automaticamente os arquivos para um formato personalizado\nLista de formatos personalizados: \n%USERNAME% - Nome de usuário\n%SOURCE_TYPE% - Tipo de fonte\n%SHORTCODE% - Código curto da publicação\n%YEAR% - Ano de download/publicação\n%2-YEAR% - Ano (dois últimos dígitos) de download/publicação\n%MONTH% - Mês de download/publicação\n%DAY% - Dia de download/publicação\n%HOUR% - Hora de download/publicação\n%MINUTE% - Minuto de download/publicação\n%SECOND% - Segundo de download/publicação\n%ORIGINAL_NAME% - Nome original do arquivo baixado\n%ORIGINAL_NAME_FIRST% - Nome original do arquivo baixado (primeira parte do nome)\n\nSe definido como falso, o nome do arquivo permanecerá inalterado.\nExemplo: instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "Define o carimbo de data/hora no formato de renomeação de arquivo para a data de publicação do recurso (fuso horário do navegador).\n\nEsse recurso só funciona quando [Renomear arquivos automaticamente] está definido como VERDADEIRO.",
     "RENAME_LOCATE_DATE_INTRO": "Modificar o formato da data do carimbo de data/hora do arquivo renomeado para a hora local do navegador e formatá-lo para o formato de data regional de sua preferência.\n\nEsse recurso só funciona quando [Renomear arquivos automaticamente] está definido como VERDADEIRO.",
@@ -62,7 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "A API de Mídia tentará obter a foto ou o vídeo da mais alta qualidade possível, mas pode demorar mais para carregar.",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "Quando a API de Mídia atingir seu limite de taxa ou não puder ser usada por outros motivos, a API de Busca Forçada será usada para baixar recursos (a qualidade do recurso pode ser um pouco menor).",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "O botão [Abrir em nova aba] nas publicações sempre usará a API de Mídia para obter recursos de alta resolução.",
+    "CHECK_FOR_UPDATE_INTRO": "Verificar atualizações quando o script é acionado (verificar a cada 300 segundos).\nAs notificações de atualização serão enviadas como notificações de desktop através do navegador.",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "Pular automaticamente quando a página de confirmação for exibida na story ou no destaque.",
     "MODIFY_RESOURCE_EXIF_INTRO": "Modificar os atributos EXIF do recurso de imagem para colocar o link do post nele.",
-    "DIRECT_DOWNLOAD_STORY_INTRO": "Ao clicar em 'Baixar todos os recursos', todas as histórias/destaques são baixadas diretamente, sem exibir a caixa de diálogo de seleção de imagens."
+    "DIRECT_DOWNLOAD_STORY_INTRO": "Ao clicar em 'Baixar todos os recursos', todas as histórias/destaques são baixadas diretamente, sem exibir a caixa de diálogo de seleção de imagens.",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Use um observador para capturar quaisquer URLs de imagens de alta qualidade na árvore DOM para o armazenamento do script, de modo que possam ser extraídos quando estiverem disponíveis e a pedido do usuário."
 }

--- a/locale/translations/ro.json
+++ b/locale/translations/ro.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "Wololo! O nouă versiune a fost lansată.",
     "NOTICE_UPDATE_CONTENT": "IG-Helper a lansat o nouă versiune, dă click aici pentru a actualiza.",
-    "CHECK_UPDATE": "Caută actualizări pentru script",
-    "CHECK_UPDATE_MENU": "Caută actualizări",
-    "CHECK_UPDATE_INTRO": "Caută actualizări atunci când scriptul este activat (verifică la fiecare 300 de secunde).\nNotificările pentru actualizare vor fi trimise ca notificări desktop prin intermediul browserului.",
+    "CHECK_FOR_UPDATE": "Caută actualizări pentru script",
     "RELOAD_SCRIPT": "Reîncarcă scriptul",
     "DONATE": "Donează",
     "FEEDBACK": "Feedback",
@@ -24,7 +22,7 @@
     "VID": "Videoclip",
     "DW": "Descarcă",
     "DW_ALL": "Descarcă toate resursele",
-    "THUMBNAIL_INTRO": "Descarcă miniatura videoclipului",
+    "VIDEO_THUMBNAIL": "Descarcă miniatura videoclipului",
     "LOAD_BLOB_ONE": "Se încarcă conținutul media în format Blob...",
     "LOAD_BLOB_MULTIPLE": "Se încarcă conținutul media în format Blob și celelalte...",
     "LOAD_BLOB_RELOAD": "Se detectează conținutul media în format Blob, se reîncarcă acum...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Folosește metode alternative pentru a descărca atunci când Media API nu este accesibil",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "„Deschide într-o filă nouă” în postări folosește întotdeauna Media API",
     "SKIP_VIEW_STORY_CONFIRM": "Omite pagina de confirmare la vizualizarea unui story/highlight",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capturează resursele de tip imagine folosind cache-ul de imagini",
     "AUTO_RENAME_INTRO": "Redenumește automat fișierele într-un format personalizat\nListă de formaturi personalizate: \n%USERNAME% - Numele de utilizator\n%SOURCE_TYPE% - Tipul sursei\n%SHORTCODE% - Codul scurt al postării\n%YEAR% - Anul descărcării/publicării\n%2-YEAR% - Anul (ultimele două cifre) descărcării/publicării\n%MONTH% - Luna descărcării/publicării\n%DAY% - Ziua descărcării/publicării\n%HOUR% - Ora descărcării/publicării\n%MINUTE% - Minutul descărcării/publicării\n%SECOND% - Secunda descărcării/publicării\n%ORIGINAL_NAME% - Numele original al fișierului descărcat\n%ORIGINAL_NAME_FIRST% - Numele original al fișierului descărcat (prima parte a numelui)\n\nDacă este setat pe fals, numele fișierului va rămâne neschimbat.\nExemplu: instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "Setează marcajul de timp în formatul de redenumire a fișierelor la data publicării resurselor (fusul orar al browserului)\n\nFuncționează DOAR dacă setarea [Redenumește automat fișierele] este pe ADEVĂRAT.",
     "RENAME_LOCATE_DATE_INTRO": "Modifică formatul de dată al marcajului de timp pentru redenumirea fișierelor la ora locală a browserului și formatează-l la formatul regional de dată dorit.\n\nFuncționează DOAR dacă setarea [Redenumește automat fișierele] este pe ADEVĂRAT.",
@@ -62,7 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "Media API va încerca să obțină cea mai înaltă calitate posibilă pentru fotografii sau videoclipuri, dar încărcarea va dura mai mult.",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "Când Media API atinge limita de rată sau nu poate fi folosit din alte motive, Forced Fetch API este folosit pentru a descărca resursele (calitatea resurselor este puțin mai scăzută).",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "Butonul [Deschide într-o filă nouă] în postări va folosi întotdeauna Media API pentru a obține resursele la rezoluție înaltă.",
+    "CHECK_FOR_UPDATE_INTRO": "Caută actualizări atunci când scriptul este activat (verifică la fiecare 300 de secunde).\nNotificările pentru actualizare vor fi trimise ca notificări desktop prin intermediul browserului.",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "Omite automat când pagina de confirmare este afișată în story sau highlight.",
     "MODIFY_RESOURCE_EXIF_INTRO": "Modifică proprietățile EXIF ale resurselor de tip imagine pentru a plasa linkul postării în acesta.",
-    "DIRECT_DOWNLOAD_STORY_INTRO": "Când dai click pe „Descarcă toate resursele”, toate storyurile/highlighturile sunt descărcate direct, fără a afișa caseta de dialog de selectare a resurselor."
+    "DIRECT_DOWNLOAD_STORY_INTRO": "Când dai click pe „Descarcă toate resursele”, toate storyurile/highlighturile sunt descărcate direct, fără a afișa caseta de dialog de selectare a resurselor.",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Folosește un observator pentru a captura orice URL-uri de imagini de înaltă calitate din arborele DOM în stocarea scriptului, astfel încât acestea să poată fi extrase atunci când sunt disponibile și la intervenția utilizatorului."
 }

--- a/locale/translations/zh-CN.json
+++ b/locale/translations/zh-CN.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "呜噜噜！新版本已发布。",
     "NOTICE_UPDATE_CONTENT": "IG小助手已发布版本更新，点击这里以更新。",
-    "CHECK_UPDATE": "检查脚本更新",
-    "CHECK_UPDATE_MENU": "检查更新",
-    "CHECK_UPDATE_INTRO": "脚本触发时检查更新 (每300秒执行一次检查)。\n更新通知将透过浏览器传送桌面通知。",
+    "CHECK_FOR_UPDATE": "检查脚本更新",
     "RELOAD_SCRIPT": "重新载入脚本",
     "DONATE": "捐助",
     "FEEDBACK": "反馈问题",
@@ -24,7 +22,7 @@
     "VID": "视频",
     "DW": "下载",
     "DW_ALL": "下载全部资源",
-    "THUMBNAIL_INTRO": "下载视频缩略图",
+    "VIDEO_THUMBNAIL": "下载视频缩略图",
     "LOAD_BLOB_ONE": "正在载入大型媒体对象...",
     "LOAD_BLOB_MULTIPLE": "正在载入多个大型媒体对象...",
     "LOAD_BLOB_RELOAD": "正在重新载入大型媒体对象...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "当 Media API 无法存取时使用其他方式下载",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "在帖子中的「在新选项卡中打开」永远使用 Media API",
     "SKIP_VIEW_STORY_CONFIRM": "自动跳过在快拍/快拍精选中显示的确认页面",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "使用 Media Cache 捕获图像资源",
     "AUTO_RENAME_INTRO": "自动将文件重命名为自定义格式\n自定义格式列表：\n%USERNAME% - 用户名\n%SOURCE_TYPE% - 下载源\n%SHORTCODE% - 帖子短码\n%YEAR% - 下载/发布的年份\n%2-YEAR% - 下载/发布的年份（后两位数）\n%MONTH% - 下载/发布的月份\n%DAY% - 下载/发布的日期\n%HOUR% - 下载/发布的小时\n%MINUTE% - 下载/发布的分钟\n%SECOND% - 下载/发布的秒\n%ORIGINAL_NAME% - 下载文件的原始名称\n%ORIGINAL_NAME_FIRST% - 下载文件的原始名称(第一部分)\n\n若设为false，则文件名将保持原样。 \n例如：instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "将文件重命名格式中的时间戳设置为资源发布日期 (浏览器时区)\n\n此功能仅在[自动重命名文件]设置为 TRUE 时有效。",
     "RENAME_LOCATE_DATE_INTRO": "修改重命名档案时间戳日期格式为浏览器当地时间，并且格式化为您所选择的地区日期格式。\n\n此功能仅在[自动重命名文件]设置为 TRUE 时有效。",
@@ -62,9 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "Media API 将尝试获取尽可能最高质量的照片或视频，但加载时间会更长。",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "当 Media API 到达速率限制或因为其他原因而无法下载时，则使用强制获取API下载资源 (资源质量略低)。",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "在帖子中的「在新选项卡中打开」功能将一律使用 Media API 取得高分辨率资源",
+    "CHECK_FOR_UPDATE_INTRO": "脚本触发时检查更新 (每300秒执行一次检查)。\n更新通知将透过浏览器传送桌面通知。",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "在查看快拍/快拍精选时，如果有确认页面时会自动跳过。",
     "MODIFY_RESOURCE_EXIF_INTRO": "修改图片资源的EXIF属性，以便将帖子链结放置于其中。",
     "DIRECT_DOWNLOAD_STORY_INTRO": "当你点击“下载所有资源”时，所有快拍/精选集会直接下载，不会显示资源选择对话框。",
-    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "使用 Media Cache 捕获图像资源",
-    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "使用观察者捕获DOM树中的任何高质量图像网址到脚本储存中，以便可用时提取。"
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "使用观察者捕获DOM树中的任何高质量图像网址到脚本储存中，以便在可用时和用户输入时提取。"
 }

--- a/locale/translations/zh-TW.json
+++ b/locale/translations/zh-TW.json
@@ -1,9 +1,7 @@
 {
     "NOTICE_UPDATE_TITLE": "嗚嚕嚕！新版本已發布。",
     "NOTICE_UPDATE_CONTENT": "IG小精靈已發布版本更新，點擊這裡以更新。",
-    "CHECK_UPDATE": "檢查腳本更新",
-    "CHECK_UPDATE_MENU": "檢查更新",
-    "CHECK_UPDATE_INTRO": "腳本觸發時檢查更新 (每300秒執行一次檢查)。\n更新通知將透過瀏覽器傳送桌面通知。",
+    "CHECK_FOR_UPDATE": "檢查腳本更新",
     "RELOAD_SCRIPT": "重新載入腳本",
     "DONATE": "贊助",
     "FEEDBACK": "回報問題",
@@ -24,7 +22,7 @@
     "VID": "影片",
     "DW": "下載",
     "DW_ALL": "下載所有資源",
-    "THUMBNAIL_INTRO": "下載影片縮圖",
+    "VIDEO_THUMBNAIL": "下載影片縮圖",
     "LOAD_BLOB_ONE": "正在載入二進位大型物件...",
     "LOAD_BLOB_MULTIPLE": "正在載入多個二進位大型物件...",
     "LOAD_BLOB_RELOAD": "正在重新載入二進位大型物件...",
@@ -48,6 +46,7 @@
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "當 Media API 無法存取時使用其他方式下載",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "在貼文中的「在新分頁中開啟」永遠使用 Media API",
     "SKIP_VIEW_STORY_CONFIRM": "自動跳過在限時動態/精選動態中顯示的確認頁面",
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "使用 Media Cache 捕獲圖像資源",
     "AUTO_RENAME_INTRO": "自動將檔案重新命名為自訂格式\n自訂格式清單:\n%USERNAME% - 使用者名稱\n%SOURCE_TYPE% - 下載來源\n%SHORTCODE% - 貼文 Shortcode\n%YEAR% - 下載/發布年份\n%2-YEAR% - 下載/發布年份（後兩位數）\n%MONTH% - 下載/發佈時的月份\n%DAY% - 下載/發佈時的日期\n%HOUR% - 下載/發佈時的小時\n%MINUTE% - 下載/發佈時的分鐘\n%SECOND% - 下載/發佈時的秒\n%ORIGINAL_NAME% - 下載檔案的原始名稱\n%ORIGINAL_NAME_FIRST% - 下載檔案的原始名稱(第一部分)\n\n若設為 false，則檔案名稱將保持原始樣貌。 \n例如：instagram_321565527_679025940443063_4318007696887450953_n.jpg",
     "RENAME_PUBLISH_DATE_INTRO": "將檔案重新命名格式中的時間戳設定為資源發佈日期 (瀏覽器時區)\n\n此功能僅在[自動重新命名檔案]設定為 TRUE 時有效。",
     "RENAME_LOCATE_DATE_INTRO": "修改重新命名檔案時間戳日期格式為瀏覽器當地時間，並且格式化為您所選擇的地區日期格式。\n\n此功能僅在[自動重新命名檔案]設定為 TRUE 時有效。",
@@ -62,9 +61,9 @@
     "FORCE_RESOURCE_VIA_MEDIA_INTRO": "Media API 將嘗試獲取盡可能最高品質的照片或影片，但加載時間會更長。",
     "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "當 Media API 到達速率限制或因為其他原因而無法下載時，則使用強制提取API下載資源 (資源品質略低)。",
     "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "在貼文中的「在新分頁中開啟」功能將一律使用 Media API 取得高解析度資源",
+    "CHECK_FOR_UPDATE_INTRO": "腳本觸發時檢查更新 (每300秒執行一次檢查)。\n更新通知將透過瀏覽器傳送桌面通知。",
     "SKIP_VIEW_STORY_CONFIRM_INTRO": "在檢視限時動態/精選動態時，若有確認頁面時將自動跳過",
     "MODIFY_RESOURCE_EXIF_INTRO": "修改圖片資源的EXIF屬性，以便將貼文連結放置於其中。",
     "DIRECT_DOWNLOAD_STORY_INTRO": "當你點擊「下載所有資源」時，所有限時動態及精選動態會直接下載，不會顯示資源選擇視窗。",
-    "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "使用 Media Cache 捕獲圖像資源",
-    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "使用觀察者捕獲DOM樹中的任何高品質圖像網址到腳本儲存空間中，以便可用時提取。"
+    "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "使用觀察者捕獲DOM樹中的任何高品質圖像網址到腳本儲存空間中，以便在可用時以及使用者輸入時進行擷取。"
 }

--- a/src/functions/highlight.js
+++ b/src/functions/highlight.js
@@ -372,7 +372,7 @@ export async function onHighlightsStoryThumbnail(isDownload) {
                 }
 
                 if ($element != null) {
-                    $element.append(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="IG_DWHISTORY_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
+                    $element.append(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="IG_DWHISTORY_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
                 }
             }
         }

--- a/src/functions/post.js
+++ b/src/functions/post.js
@@ -209,7 +209,7 @@ export function createDownloadButton() {
                 // Add icons
                 const DownloadElement = `<div data-ih-locale-title="DW" title="${_i18n("DW")}" class="IG_DW_MAIN">${SVG.DOWNLOAD}</div>`;
                 const NewTabElement = `<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="IG_NEWTAB_MAIN">${SVG.NEW_TAB}</div>`;
-                const ThumbnailElement = `<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="IG_THUMBNAIL_MAIN">${SVG.THUMBNAIL}</div>`;
+                const ThumbnailElement = `<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="IG_THUMBNAIL_MAIN">${SVG.THUMBNAIL}</div>`;
                 const ViewerElement = `<div data-ih-locale-title="IMAGE_VIEWER" title="${_i18n("IMAGE_VIEWER")}" class="IG_IMAGE_VIEWER">${SVG.FULLSCREEN}</div>`;
 
                 $childElement.find(".button_wrapper").append(DownloadElement);
@@ -413,7 +413,7 @@ export function createDownloadButton() {
                         $(this).after(`<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="newTab">${SVG.NEW_TAB}</div>`);
 
                         if ($(this).attr('data-name') == 'video') {
-                            $(this).after(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
+                            $(this).after(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
                         }
                     });
 
@@ -544,7 +544,7 @@ export function createDownloadButton() {
                         $(this).after(`<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="newTab">${SVG.NEW_TAB}</div>`);
 
                         if ($(this).attr('data-name') == 'video') {
-                            $(this).after(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
+                            $(this).after(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
                         }
                     });
 
@@ -709,7 +709,7 @@ export async function createMediaListDOM(postURL, selector, message) {
             $(this).after(`<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="newTab">${SVG.NEW_TAB}</div>`);
 
             if ($(this).attr('data-name') == 'video') {
-                $(this).after(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
+                $(this).after(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
             }
         });
     }

--- a/src/functions/reel.js
+++ b/src/functions/reel.js
@@ -107,7 +107,7 @@ export async function onReels(isDownload, isVideo, isPreview) {
 
                                 $(this).children().append(`<div data-ih-locale-title="DW" title="${_i18n("DW")}" class="IG_REELS">${SVG.DOWNLOAD}</div>`);
                                 $(this).children().append(`<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="IG_REELS_NEWTAB">${SVG.NEW_TAB}</div>`);
-                                $(this).children().append(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="IG_REELS_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
+                                $(this).children().append(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="IG_REELS_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
 
                                 // Disable video autoplay
                                 if (USER_SETTING.DISABLE_VIDEO_LOOPING) {

--- a/src/functions/story.js
+++ b/src/functions/story.js
@@ -50,7 +50,7 @@ export async function createStoryListDOM(obj, type) {
             $(this).after(`<div data-ih-locale-title="NEW_TAB" title="${_i18n("NEW_TAB")}" class="newTab">${SVG.NEW_TAB}</div>`);
 
             if ($(this).attr('data-type') == 'mp4') {
-                $(this).after(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
+                $(this).after(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="videoThumbnail">${SVG.THUMBNAIL}</div>`);
             }
         });
 
@@ -706,7 +706,7 @@ export async function onStoryThumbnail(isDownload, isForce) {
 
             if ($element != null) {
                 $element.first().css('position', 'relative');
-                $element.first().append(`<div data-ih-locale-title="THUMBNAIL_INTRO" title="${_i18n("THUMBNAIL_INTRO")}" class="IG_DWSTORY_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
+                $element.first().append(`<div data-ih-locale-title="VIDEO_THUMBNAIL" title="${_i18n("VIDEO_THUMBNAIL")}" class="IG_DWSTORY_THUMBNAIL">${SVG.THUMBNAIL}</div>`);
             }
 
         }

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,7 +6,8 @@ import { onReadyMyDW } from "./functions/post";
 // ??? PLEASE CHANGE SETTING WITH MENU ???
 export const USER_SETTING = {
     'AUTO_RENAME': true,
-    'CHECK_UPDATE': true,
+    'CAPTURE_IMAGE_VIA_MEDIA_CACHE': true,
+    'CHECK_FOR_UPDATE': true,
     'DIRECT_DOWNLOAD_ALL': false,
     'DIRECT_DOWNLOAD_STORY': false,
     'DIRECT_DOWNLOAD_VISIBLE_RESOURCE': false,
@@ -21,8 +22,7 @@ export const USER_SETTING = {
     'REDIRECT_CLICK_USER_STORY_PICTURE': false,
     'RENAME_PUBLISH_DATE': true,
     'SCROLL_BUTTON': true,
-    'SKIP_VIEW_STORY_CONFIRM': false,
-    'CAPTURE_IMAGE_VIA_MEDIA_CACHE': true
+    'SKIP_VIEW_STORY_CONFIRM': false
 };
 
 export const PARENT_CHILD_MAPPING = {

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -553,7 +553,7 @@ export function registerMenuCommand() {
         accessKey: "f"
     }));
 
-    state.registerMenuIds.push(GM_registerMenuCommand(_i18n('CHECK_UPDATE_MENU'), () => {
+    state.registerMenuIds.push(GM_registerMenuCommand(_i18n('CHECK_FOR_UPDATE'), () => {
         callNotification();
     }, {
         accessKey: "c"
@@ -574,7 +574,7 @@ export function registerMenuCommand() {
  * @return {void}
  */
 export function checkingScriptUpdate(interval) {
-    if (!USER_SETTING.CHECK_UPDATE) return;
+    if (!USER_SETTING.CHECK_FOR_UPDATE) return;
 
     const check_timestamp = GM_getValue('G_CHECK_TIMESTAMP') ?? new Date().getTime();
     const now_time = new Date().getTime();
@@ -699,7 +699,7 @@ export function showSetting() {
         }
     }
 
-    $('.IG_POPUP_DIG .IG_POPUP_DIG_BODY input#CHECK_UPDATE').closest('label').prependTo('.IG_POPUP_DIG .IG_POPUP_DIG_BODY');
+    $('.IG_POPUP_DIG .IG_POPUP_DIG_BODY input#CHECK_FOR_UPDATE').closest('label').prependTo('.IG_POPUP_DIG .IG_POPUP_DIG_BODY');
 
     arrangeSettingHierarchy();
 }

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -13,9 +13,7 @@ export function translateText() {
         "en-US": {
             "NOTICE_UPDATE_TITLE": "Wololo! New version released.",
             "NOTICE_UPDATE_CONTENT": "IG-Helper has released a new version, click here to update.",
-            "CHECK_UPDATE": "Checking for Script Updates",
-            "CHECK_UPDATE_MENU": "Checking for Updates",
-            "CHECK_UPDATE_INTRO": "Check for updates when the script is triggered (check every 300 seconds).\nUpdate notifications will be sent as desktop notifications through the browser.",
+            "CHECK_FOR_UPDATE": "Check for Script Updates",
             "RELOAD_SCRIPT": "Reload Script",
             "DONATE": "Donate",
             "FEEDBACK": "Feedback",
@@ -36,7 +34,7 @@ export function translateText() {
             "VID": "Video",
             "DW": "Download",
             "DW_ALL": "Download All Resources",
-            "THUMBNAIL_INTRO": "Download Video Thumbnail",
+            "VIDEO_THUMBNAIL": "Download Video Thumbnail",
             "LOAD_BLOB_ONE": "Loading Blob Media...",
             "LOAD_BLOB_MULTIPLE": "Loading Blob Media and Others...",
             "LOAD_BLOB_RELOAD": "Detecting Blob Media, reloading...",
@@ -60,6 +58,7 @@ export function translateText() {
             "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED": "Use Alternative Methods to Download When the Media API is Not Accessible",
             "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST": "Always Use Media API for 'Open in New Tab' in Posts",
             "SKIP_VIEW_STORY_CONFIRM": "Skip the Confirmation Page for Viewing a Story/Highlight",
+            "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capture Image Resource Using Media Cache",
             "AUTO_RENAME_INTRO": "Auto rename file to custom format:\nCustom Format List: \n%USERNAME% - Username\n%SOURCE_TYPE% - Download Source\n%SHORTCODE% - Post Shortcode\n%YEAR% - Year when downloaded/published\n%2-YEAR% - Year (last two digits) when downloaded/published\n%MONTH% - Month when downloaded/published\n%DAY% - Day when downloaded/published\n%HOUR% - Hour when downloaded/published\n%MINUTE% - Minute when downloaded/published\n%SECOND% - Second when downloaded/published\n%ORIGINAL_NAME% - Original name of downloaded file\n%ORIGINAL_NAME_FIRST% - Original name of downloaded file (first part of name)\n\nIf set to false, the file name will remain unchanged.\nExample: instagram_321565527_679025940443063_4318007696887450953_n.jpg",
             "RENAME_PUBLISH_DATE_INTRO": "Sets the timestamp in the file rename format to the resource publish date (browser time zone).\n\nThis feature only works when [Automatically Rename Files] is set to TRUE.",
             "RENAME_LOCATE_DATE_INTRO": "Modify the renamed file timestamp date format to the browser's local time, and format it to your preferred regional date format.\n\nThis feature only works when [Automatically Rename Files] is set to TRUE.",
@@ -74,11 +73,11 @@ export function translateText() {
             "FORCE_RESOURCE_VIA_MEDIA_INTRO": "The Media API will try to get the highest quality photo or video possible, but it may take longer to load.",
             "FALLBACK_TO_BLOB_FETCH_IF_MEDIA_API_THROTTLED_INTRO": "When the Media API reaches its rate limit or cannot be used for other reasons, the Forced Fetch API will be used to download resources (the resource quality may be slightly lower).",
             "NEW_TAB_ALWAYS_FORCE_MEDIA_IN_POST_INTRO": "The [Open in New Tab] button in posts will always use the Media API to obtain high-resolution resources.",
+            "CHECK_FOR_UPDATE_INTRO": "Check for updates when the script is triggered (check every 300 seconds).\nUpdate notifications will be sent as desktop notifications through the browser.",
             "SKIP_VIEW_STORY_CONFIRM_INTRO": "Automatically skip when confirmation page is shown in story or highlight.",
             "MODIFY_RESOURCE_EXIF_INTRO": "Modify the EXIF properties of the image resource to place the post link in it.",
             "DIRECT_DOWNLOAD_STORY_INTRO": "When you click Download All Resources, all stories/highlights are downloaded directly, without showing the image selection dialog.",
-            "CAPTURE_IMAGE_VIA_MEDIA_CACHE": "Capturing Image Resource Using Media Cache",
-            "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Use a watcher to capture any high-quality image URLs in the DOM tree into the script storage so that they can be extracted when available.",
+            "CAPTURE_IMAGE_VIA_MEDIA_CACHE_INTRO": "Use a watcher to capture any high-quality image URLs in the DOM tree into the script’s storage so that they can be extracted when available and upon user input.",
         }
     };
 


### PR DESCRIPTION
- Added missing translations
- Made minor updates to the en-US, zh-TW and zh-CN translations
- Renamed '**_THUMBNAIL_INTRO_**' to '**_VIDEO_THUMBNAIL_**' (all `..._INTRO` strings are longer descriptions of options, here it was for an action of a button)
- Removed `CHECK_UPDATE_MENU` and replaced with `CHECK_FOR_UPDATE`
- Reordered translations: main options are listed in the order they appear in the Settings window, while the `..._INTRO` strings remain grouped in the order they were originally added (at least this applies to the last `..._INTRO` strings)