### PR TITLE
Relax a little bit regex rule for image cache

### DIFF
--- a/src/utils/image_cache.js
+++ b/src/utils/image_cache.js
@@ -102,7 +102,7 @@ export function registerPerformanceObserver() {
             if (entry.initiatorType === 'img') {
                 const u = entry.name;
 
-                if (!(u.includes('_e35') || u.includes('_e15') || u.includes('.webp?efg=')) || u.match(/_[sp](\d+)x\1(?!\d)/)) return;
+                if (!(u.includes('_e35') || u.includes('_e15') || u.includes('.webp?')) || u.match(/_[sp](\d+)x\1(?!\d)/)) return;
                 const id = mediaIdFromURL(u);
                 if (id && !state.GL_imageCache[id]) putInCache(id, u);
             }


### PR DESCRIPTION
The image URL could also look like this: `https://scontent.cdninstagram.com/v/t51.82787-15/528566768_18121952302474589_8073071504952371442_n.webp?_nc_cat=102&cb=30a688f7-5ec5f577&ig_cache_key=MzY5MTg2NTIyMzM0NTU3NzAyMQ%3D%3D.3-ccb1-7-cb30a688f7-5ec5f577&ccb=1-7&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjEwODB4MTkyMC5zZHIuQzMifQ%3D%3D&_nc_ohc=W8dGNgcMa5gQ7kNvwGicgJP&_nc_oc=Adm3RKudLv0Np3edaGYXM5r62o9dlnrBdvrLrJygyPRHcZGs-sOl-Sdd82Am9BMeWY-BFYvnjhxNuJLIL5HfC-hT&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent.cdninstagram.com&_nc_gid=fStoIU9c3SpPzCtMOdm2Xg&oh=00_AfVoeI4PyfedbRKbapgHC2KeMAGLGc-pHOBNILX5XrHNLA&oe=6896F2E0`

Notice:
... <ins>.webp?_nc_cat=</ins> ...

So it's not always `.webp?efg=`

If image URL is not highest res, the URL for webp will look like this: `_n.webp?stp=dst-webp_p720x720&efg=`

`.webp?` should be enough, given that there is already `u.match(/_[sp](\d+)x\1(?!\d)/)` .