### PR TITLE
Expand Media Cache

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -206,6 +206,16 @@ $(function () {
         }
 
         let postPath = $(this).parent().children('a').attr('data-path') ?? $('#article-id').text();
+		
+        if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+            let mediaId = $(element).attr('media-id');
+            const cached = getImageFromCache(mediaId);
+            if (cached) {
+                logger("[Restore Cached postThumbnail]", postPath);
+                saveFiles(cached, $(this).parent().children('a').attr('data-username'), 'thumbnail', timestamp, 'jpg', postPath);
+                return;
+            }
+        }
 
         saveFiles($(this).parent().children('a').find('img').first().attr('src'), $(this).parent().children('a').attr('data-username'), 'thumbnail', timestamp, 'jpg', postPath);
     });

--- a/src/functions/highlight.js
+++ b/src/functions/highlight.js
@@ -315,6 +315,15 @@ export async function onHighlightsStoryThumbnail(isDownload) {
             timestamp = target.taken_at_timestamp;
         }
 
+        if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+            const cached = getImageFromCache(highlightId);
+            if (cached) {
+                logger("[Restore Cached onHighlightsStoryThumbnail]", highlightId);
+                saveFiles(cached, username, "stories", timestamp, 'jpg', highlightId);
+                return;
+            }
+        }
+
         if (USER_SETTING.FORCE_RESOURCE_VIA_MEDIA && !state.tempFetchRateLimit) {
             let result = await getMediaInfo(target.id);
 

--- a/src/functions/story.js
+++ b/src/functions/story.js
@@ -559,6 +559,15 @@ export async function onStoryThumbnail(isDownload, isForce) {
             if (mediaId == null) {
                 mediaId = location.pathname.split('/').filter(s => s.length > 0 && s.match(/^([0-9]{10,})$/)).at(-1);
             }
+			
+            if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+                const cached = getImageFromCache(mediaId);
+                if (cached) {
+                    logger("[Restore Cached onStoryThumbnail]", mediaId);
+                    saveFiles(cached, username, "stories", timestamp, 'jpg', mediaId);
+                    return;
+                }
+            }
 
             let result = await getMediaInfo(mediaId);
 

--- a/src/utils/image_cache.js
+++ b/src/utils/image_cache.js
@@ -99,7 +99,7 @@ export function registerPerformanceObserver() {
         if (!USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) return;
 
         list.getEntries().forEach(entry => {
-            if (entry.initiatorType === 'img') {
+            if (entry.initiatorType === 'img' || entry.initiatorType === 'fetch') {
                 const u = entry.name;
 
                 if (!(u.includes('_e35') || u.includes('_e15') || u.includes('.webp?')) || u.match(/_[sp](\d+)x\1(?!\d)/)) return;


### PR DESCRIPTION
Because why not?

Sometimes, Instagram exposes URL images used as thumbnails. So the media cache captures them even if our intention wasn't to capture the thumbnails. What is weird is that it doesn't happen all the time.

This commit currently doesn't work very well.

The only thing that seems to work okay is the changes done to the story. js.

Have no idea if it's possible to make this work for highlights as well.

Very likely, this idea should/could work for regular posts as well, but my implementation in event.js is bad (mediaId is not fetched). 🤔

This thing `entry.initiatorType === 'fetch'` is useful to capture the URLs that are requested via APIs (like Media API), but I'm not sure if those URLs will be saved correctly or how we can take advantage of the data we capture this way. 🤔