### PR TITLE
Expand Media Cache

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -223,6 +223,22 @@ $(function () {
         }
 
         let postPath = $(this).parent().children('a').attr('data-path') ?? $('#article-id').text();
+		
+        if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+            const mediaId = $(this).parent().children('a').first().attr('media-id');
+            const cached = getImageFromCache(mediaId);
+            if (cached) {
+                logger("[Restore Cached postThumbnail]", mediaId);
+                saveFiles(cached, {
+                    username: $(this).parent().children('a').attr('data-username'),
+                    sourceType: 'thumbnail',
+                    timestamp,
+                    filetype: 'jpg',
+                    shortcode: postPath
+                });
+                return;
+            }
+        }
 
         saveFiles(
             $(this).parent().children('a').find('img').first().attr('src'),

--- a/src/functions/highlight.js
+++ b/src/functions/highlight.js
@@ -406,6 +406,21 @@ export async function onHighlightsStoryThumbnail(isDownload) {
         if (USER_SETTING.RENAME_PUBLISH_DATE) {
             timestamp = target.taken_at_timestamp;
         }
+		
+        if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+            const cached = getImageFromCache(target.id);
+            if (cached) {
+                logger("[Restore Cached onHighlightsStoryThumbnail]", target.id);
+                saveFiles(cached, {
+                    username,
+                    sourceType: "highlights",
+                    timestamp,
+                    filetype: 'jpg',
+                    shortcode: target.id
+                });
+                return;
+            }
+        }
 
         if (USER_SETTING.FORCE_RESOURCE_VIA_MEDIA && !state.tempFetchRateLimit) {
             let result = await getMediaInfo(target.id);

--- a/src/functions/story.js
+++ b/src/functions/story.js
@@ -636,6 +636,21 @@ export async function onStoryThumbnail(isDownload, isForce) {
             if (mediaId == null) {
                 mediaId = location.pathname.split('/').filter(s => s.length > 0 && s.match(/^([0-9]{10,})$/)).at(-1);
             }
+			
+            if (USER_SETTING.CAPTURE_IMAGE_VIA_MEDIA_CACHE) {
+                const cached = getImageFromCache(mediaId);
+                if (cached) {
+                    logger("[Restore Cached onStoryThumbnail]", mediaId);
+                    saveFiles(cached, {
+                        username,
+                        sourceType: "stories",
+                        timestamp,
+                        filetype: 'jpg',
+                        shortcode: mediaId
+                    });
+                    return;
+                }
+            }
 
             let result = await getMediaInfo(mediaId);
 

--- a/src/utils/image_cache.js
+++ b/src/utils/image_cache.js
@@ -102,7 +102,13 @@ export function registerPerformanceObserver() {
             if (entry.initiatorType === 'img') {
                 const u = entry.name;
 
-                if (!(u.includes('_e35') || u.includes('_e15') || u.includes('.webp?')) || u.match(/_[sp](\d+)x\1(?!\d)/)) return;
+                if (!(u.includes('_e35') || u.includes('_e15') || u.includes('.webp?')) ||
+                    u.includes('_e35_s') || 
+                    u.match(/_[sp](\d+)x\1(?!\d)/)
+                ) {
+                    return;
+                }
+				
                 const id = mediaIdFromURL(u);
                 if (id && !state.GL_imageCache[id]) putInCache(id, u);
             }


### PR DESCRIPTION
Because why not? Sometimes, Instagram exposes URL images used as thumbnails, so the media cache captures them even if our intention wasn't to capture the thumbnails. What is weird is that it doesn't happen all the time.

I'm not sure if the changes made to the highlight.js file are actually doing anything. 🤔
