### PR TITLE
fix: repair post image download flows

### DIFF
--- a/main.js
+++ b/main.js
@@ -1610,14 +1610,13 @@
                             }
                         });
 
-                        if (blob || USER_SETTING.FORCE_RESOURCE_VIA_MEDIA) {
-                            await createMediaListDOM(
-                                state.GL_postPath,
-                                ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
-                                _i18n("LOAD_BLOB_MULTIPLE")
-                            );
-                        }
-                        else {
+                        const totalInserted = await createMediaListDOM(
+                            state.GL_postPath,
+                            ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
+                            _i18n("LOAD_BLOB_MULTIPLE")
+                        );
+
+                        if (!totalInserted || totalInserted < 1) {
                             const $popupBody = $('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY');
                             $resourceItems.each(function () {
                                 s++;
@@ -1633,14 +1632,6 @@
                                     $popupBody.append(`<a datetime="${publish_time}" data-needed="direct" data-path="${state.GL_postPath}" data-name="photo" data-type="jpg" data-globalIndex="${s}" href="javascript:;" data-href="${imgLink}"><img width="100" src="${imgLink}" /><br/>- <span data-ih-locale="IMG">${_i18n("IMG")}</span> ${s} -</a>`);
                                 }
                             });
-
-                            if (blob) {
-                                await createMediaListDOM(
-                                    state.GL_postPath,
-                                    ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
-                                    _i18n("LOAD_BLOB_RELOAD")
-                                );
-                            }
                         }
                     }
                     else {
@@ -1668,6 +1659,14 @@
                                 $('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY').append(`<a datetime="${publish_time}" data-needed="direct" data-path="${state.GL_postPath}" data-name="photo" data-type="jpg" data-globalIndex="${s}" href="javascript:;" href="" data-href="${imgLink}"><img width="100" src="${imgLink}" /><br/>- <span data-ih-locale="IMG">${_i18n("IMG")}</span> ${s} -</a>`);
                             }
                         }
+                    }
+
+                    // Manual image-only paths do not pass through createMediaListDOM(),
+                    // so the popup action buttons must be re-enabled here as soon as we
+                    // have at least one downloadable resource in the dialog.
+                    if ($('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY a[data-needed="direct"]').length > 0) {
+                        $('.IG_POPUP_DIG #batch_download_selected, .IG_POPUP_DIG #batch_download_direct').prop('disabled', false);
+                        updatePopupSelectionSummary();
                     }
                 }
 
@@ -3479,7 +3478,8 @@
                             // eslint-disable-next-line no-unused-vars
                         }).catch((err) => {
                             userIdCache.delete(username);
-                            alert("Cannot find user info from getUserId()");
+                            logger('getUserId()', 'fallback reject', err);
+                            reject(err);
                         });
                     }
                 },
@@ -4803,7 +4803,7 @@
 
             let date = new Date().getTime();
             let timestamp = Math.floor(date / 1000);
-            let username = $el.data('username') ? $el.data('username') : state.GLusername;
+            let username = $el.data('username') ? $el.data('username') : state.GL_username;
             let index = parseInt($el.attr('data-globalindex') || 0, 10) || 0;
 
             if (!username && $el.data('path')) {

--- a/src/functions/post.js
+++ b/src/functions/post.js
@@ -706,14 +706,13 @@ export function registerPostClickHandlers() {
                         }
                     });
 
-                    if (blob || USER_SETTING.FORCE_RESOURCE_VIA_MEDIA) {
-                        await createMediaListDOM(
-                            state.GL_postPath,
-                            ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
-                            _i18n("LOAD_BLOB_MULTIPLE")
-                        );
-                    }
-                    else {
+                    const totalInserted = await createMediaListDOM(
+                        state.GL_postPath,
+                        ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
+                        _i18n("LOAD_BLOB_MULTIPLE")
+                    );
+
+                    if (!totalInserted || totalInserted < 1) {
                         const $popupBody = $('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY');
                         $resourceItems.each(function () {
                             s++;
@@ -729,14 +728,6 @@ export function registerPostClickHandlers() {
                                 $popupBody.append(`<a datetime="${publish_time}" data-needed="direct" data-path="${state.GL_postPath}" data-name="photo" data-type="jpg" data-globalIndex="${s}" href="javascript:;" data-href="${imgLink}"><img width="100" src="${imgLink}" /><br/>- <span data-ih-locale="IMG">${_i18n("IMG")}</span> ${s} -</a>`);
                             }
                         });
-
-                        if (blob) {
-                            await createMediaListDOM(
-                                state.GL_postPath,
-                                ".IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY",
-                                _i18n("LOAD_BLOB_RELOAD")
-                            );
-                        }
                     }
                 }
                 else {
@@ -764,6 +755,14 @@ export function registerPostClickHandlers() {
                             $('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY').append(`<a datetime="${publish_time}" data-needed="direct" data-path="${state.GL_postPath}" data-name="photo" data-type="jpg" data-globalIndex="${s}" href="javascript:;" href="" data-href="${imgLink}"><img width="100" src="${imgLink}" /><br/>- <span data-ih-locale="IMG">${_i18n("IMG")}</span> ${s} -</a>`);
                         }
                     }
+                }
+
+                // Manual image-only paths do not pass through createMediaListDOM(),
+                // so the popup action buttons must be re-enabled here as soon as we
+                // have at least one downloadable resource in the dialog.
+                if ($('.IG_POPUP_DIG .IG_POPUP_DIG_MAIN .IG_POPUP_DIG_BODY a[data-needed="direct"]').length > 0) {
+                    $('.IG_POPUP_DIG #batch_download_selected, .IG_POPUP_DIG #batch_download_direct').prop('disabled', false);
+                    updatePopupSelectionSummary();
                 }
             }
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -109,7 +109,8 @@ export function getUserId(username) {
                         // eslint-disable-next-line no-unused-vars
                     }).catch((err) => {
                         userIdCache.delete(username);
-                        alert("Cannot find user info from getUserId()");
+                        logger('getUserId()', 'fallback reject', err);
+                        reject(err);
                     });
                 }
             },

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1031,7 +1031,7 @@ export async function triggerLinkElement($element, isPreview = false) {
 
         let date = new Date().getTime();
         let timestamp = Math.floor(date / 1000);
-        let username = $el.data('username') ? $el.data('username') : state.GLusername;
+        let username = $el.data('username') ? $el.data('username') : state.GL_username;
         let index = parseInt($el.attr('data-globalindex') || 0, 10) || 0;
 
         if (!username && $el.data('path')) {


### PR DESCRIPTION
This PR fixes several issues affecting image downloads in posts:

- Corrects username resolution in the post download flow by using the proper state.GL_username field.
- Prevents getUserId() from getting stuck when the fallback lookup fails.
- Re-enables the batch action buttons in the popup when image resources are available.
- Ensures multi-image posts populate the popup from the full media list instead of only the currently visible carousel items.

**Verification**
Ran npm run build successfully.