### PR TITLE
fix: normalize save filename timestamps

### DIFF
--- a/main.js
+++ b/main.js
@@ -4170,6 +4170,39 @@
     }
 
     /**
+     * normalizeTimestampToMs
+     * @description Normalize a timestamp value to milliseconds.
+     *
+     * @param {unknown} value
+     * @return {number}
+     */
+    function normalizeTimestampToMs(value) {
+        const numeric = Number(value);
+        if (!Number.isFinite(numeric)) {
+            return Date.now();
+        }
+
+        const abs = Math.abs(numeric);
+
+        // Instagram usually returns seconds or milliseconds, but we also tolerate
+        // microseconds/nanoseconds by scaling down based on magnitude instead of
+        // assuming a fixed digit count.
+        if (abs < 1e11) {
+            return Math.trunc(numeric * 1000);
+        }
+
+        if (abs < 1e14) {
+            return Math.trunc(numeric);
+        }
+
+        if (abs < 1e17) {
+            return Math.trunc(numeric / 1000);
+        }
+
+        return Math.trunc(numeric / 1000000);
+    }
+
+    /**
      * fetchArrayBuffer
      * @description Download URL as ArrayBuffer.
      *
@@ -4482,7 +4515,7 @@
      */
     function getSaveFileName(downloadLink, metadata) {
         let { username, sourceType, timestamp, filetype, shortcode, index, uid } = metadata;
-        timestamp = parseInt(timestamp.toString().padEnd(13, '0'));
+        timestamp = normalizeTimestampToMs(timestamp);
         index = (index != null) ? index : 0;
 
         const date = new Date(timestamp);

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -398,6 +398,39 @@ export function saveFiles(downloadLink, metadata) {
 }
 
 /**
+ * normalizeTimestampToMs
+ * @description Normalize a timestamp value to milliseconds.
+ *
+ * @param {unknown} value
+ * @return {number}
+ */
+function normalizeTimestampToMs(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return Date.now();
+    }
+
+    const abs = Math.abs(numeric);
+
+    // Instagram usually returns seconds or milliseconds, but we also tolerate
+    // microseconds/nanoseconds by scaling down based on magnitude instead of
+    // assuming a fixed digit count.
+    if (abs < 1e11) {
+        return Math.trunc(numeric * 1000);
+    }
+
+    if (abs < 1e14) {
+        return Math.trunc(numeric);
+    }
+
+    if (abs < 1e17) {
+        return Math.trunc(numeric / 1000);
+    }
+
+    return Math.trunc(numeric / 1000000);
+}
+
+/**
  * fetchArrayBuffer
  * @description Download URL as ArrayBuffer.
  *
@@ -710,7 +743,7 @@ export function triggerDownload(blob, filename) {
  */
 export function getSaveFileName(downloadLink, metadata) {
     let { username, sourceType, timestamp, filetype, shortcode, index, uid } = metadata;
-    timestamp = parseInt(timestamp.toString().padEnd(13, '0'));
+    timestamp = normalizeTimestampToMs(timestamp);
     index = (index != null) ? index : 0;
 
     const date = new Date(timestamp);


### PR DESCRIPTION
This PR improves the robustness of filename generation by normalizing timestamps by magnitude instead of assuming a fixed length.

Changes include:

- Replaces `padEnd(13, '0')` with normalization based on `Number(...)` and `Math.trunc(...)`.
- Supports timestamps in seconds, milliseconds, microseconds, and nanoseconds.
- Uses `Date.now()` as a fallback when the value is non-numeric or invalid.

Verification:
`npm run build` completed successfully.